### PR TITLE
use has_attribute? instead of respond_to for after_initialize.

### DIFF
--- a/lib/destroyed_at.rb
+++ b/lib/destroyed_at.rb
@@ -33,7 +33,7 @@ module DestroyedAt
   private
 
   def _set_destruction_state
-    @destroyed = destroyed_at.present? if respond_to?(:destroyed_at)
+    @destroyed = destroyed_at.present? if has_attribute?(:destroyed_at)
     # Don't stop the other callbacks from running
     true
   end


### PR DESCRIPTION
If you write a query with a select clause that does not return destroyed_at, and build models in the call, the .present? call on destroyed_at in the after_initialize will fail with an ActiveModel::MissingAttributeError. This is an example of:

http://stackoverflow.com/questions/6820156/activemodelmissingattributeerror-occurs-after-deploying-and-then-goes-away-aft

Switching to using has_attribute? fixes this.
