### PR TITLE
exclude patch level on pessimistic version constraint

### DIFF
--- a/destroyed_at.gemspec
+++ b/destroyed_at.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0'
 
-  spec.add_runtime_dependency "activerecord", "~> 4.0.0"
-  spec.add_runtime_dependency 'actionpack', '~> 4.0.0'
+  spec.add_runtime_dependency "activerecord", "~> 4.0"
+  spec.add_runtime_dependency 'actionpack', '~> 4.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
this allows use of activerecord/actionpack 4.1
