### PR TITLE
Updates for Rails 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## 0.4.0
+
+* Updates for Rails 4.1
+* Removes `.with_default_scope` which has been deprecated.
 * Enables retrieval of destroyed objects by time via `.destroyed`
   method, which now takes an optional time attribute. - Lin Reid & Dan
 McClain
+* Removes `m` as a development dependency, since it is not compatible
+  with `minitest 5`.
 
 ## 0.3.1
+**Stable for Rails 4.0**
 
 * [Bug] Fixed route not raising when resource constant does not exist -
   Brian Cardarella

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ on how to properly submit issues and pull requests.
 
 ## Legal ##
 
-[DockYard](http://dockyard.com) Inc. &copy; 2013
+[DockYard](http://dockyard.com) Inc. &copy; 2014
 
 [@dockyard](http://twitter.com/dockyard)
 

--- a/destroyed_at.gemspec
+++ b/destroyed_at.gemspec
@@ -17,15 +17,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.1'
 
-  spec.add_runtime_dependency "activerecord", "~> 4.0"
-  spec.add_runtime_dependency 'actionpack', '~> 4.0'
+  spec.add_runtime_dependency "activerecord", '~> 4.1'
+  spec.add_runtime_dependency 'actionpack', '~> 4.1'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest"
-  spec.add_development_dependency "m"
+  spec.add_development_dependency "minitest", "~> 5.1"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "timecop"

--- a/lib/destroyed_at.rb
+++ b/lib/destroyed_at.rb
@@ -16,7 +16,7 @@ module DestroyedAt
 
   module ClassMethods
     def destroyed(time = nil)
-      query = all.with_default_scope
+      query = where.not(destroyed_at: nil)
       query.where_values.reject! do |node|
         Arel::Nodes::Equality === node && node.left.name == 'destroyed_at' && node.right.nil?
       end

--- a/lib/destroyed_at/version.rb
+++ b/lib/destroyed_at/version.rb
@@ -1,3 +1,3 @@
 module DestroyedAt
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Removes `.with_default_scope` which has been deprecated.

Enables retrieval of destroyed objects by time via `.destroyed` method, which now takes an optional time attribute. - Lin Reid & Dan McClain

@danmcclain @bcardarella Please merge or let me know if you have any questions. I plan on doing a release once this merged into master.
