### PR TITLE
Use `Resource#singular` for determining class name

### DIFF
--- a/lib/destroyed_at/mapper.rb
+++ b/lib/destroyed_at/mapper.rb
@@ -14,7 +14,7 @@ ActionDispatch::Routing::Mapper.send(:prepend, DestroyedAt::Routes)
 module DestroyedAt::Resource
   def default_actions
     actions = super
-    class_name = self.name.camelcase.singularize
+    class_name = self.singular.camelcase
 
     if Module.const_defined?(class_name) && class_name.constantize.included_modules.include?(DestroyedAt)
       actions << :restore

--- a/lib/destroyed_at/routes.rb
+++ b/lib/destroyed_at/routes.rb
@@ -13,7 +13,7 @@ module DestroyedAt::Mapper
   module Resource
     def default_actions
       actions = super
-      if self.name.camelcase.singularize.constantize.included_modules.include?(DestroyedAt)
+      if self.singular.camelcase.constantize.included_modules.include?(DestroyedAt)
         actions << :restore
       end
 

--- a/test/mapper_test.rb
+++ b/test/mapper_test.rb
@@ -71,6 +71,19 @@ class MapperTest < ActiveSupport::TestCase
     end
   end
 
+  test 'does not raise if `:as` option is used in routes' do
+    draw do
+      resources :cars, as: :automobiles
+    end
+
+    begin
+      @set.recognize_path('/cars', method: :get)
+      assert true, 'path recognized'
+    rescue ActionController::RoutingError
+      assert false, 'this should not be reached'
+    end
+  end
+
   private
 
   def draw(&block)


### PR DESCRIPTION
`Resource#name` can return a name or string depending on if the `:as`
option was used when drawing routes. `Resource#singular` always returns
a string and handles singularizing the route name.
