### PR TITLE
support Ruby 2.0 or greater

### DIFF
--- a/destroyed_at.gemspec
+++ b/destroyed_at.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '~> 2.0'
 
   spec.add_runtime_dependency "activerecord", '~> 4.1'
   spec.add_runtime_dependency 'actionpack', '~> 4.1'


### PR DESCRIPTION
Your travis file is still testing against Ruby 2.0 yet you have prevented it's use in the gemspec. This update would allow those on Rails 4.1 to still have the option of using Ruby 2.0 until Ruby 2.1.x fixes it's memory leak issues:
- http://www.omniref.com/blog/blog/2014/03/27/ruby-garbage-collection-still-not-ready-for-production/
- https://discussion.heroku.com/t/memory-leaks-with-ruby-2-1-2/644
- https://github.com/rails/rails/issues/15243 

This addresses #42 
