### PR TITLE
Adds issues_tests for testing GitHub issues.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,16 @@ Rake::TestTask.new(:test) do |t|
   t.verbose = false
 end
 
+# Allows us to add tests specific to GitHub issues. These won't get run when `rake` is called,
+# so they shouldn't slow down the test suite unless you explicitly want to run them with 
+# `rake issues_tests`.
+#
+Rake::TestTask.new(:issues_tests) do |t|
+  t.description = 'Run tests pertaining to open GitHub issues.'
+  t.libs << 'lib'
+  t.libs << 'test'
+  t.pattern = 'test/**/issues_tests.rb'
+  t.verbose = false
+end
+
 task :default => :test

--- a/test/issues_tests.rb
+++ b/test/issues_tests.rb
@@ -1,0 +1,32 @@
+# Tests pertaining to opened issues.
+
+# These tests will not run when `rake` is called;
+# They must be called explicitly `rake issue_tests`.
+
+require 'test_helper'
+
+describe 'https://github.com/dockyard/destroyed_at/issues/46' do
+  module Issue46
+    class UserQuestion < ActiveRecord::Base
+      has_one :video_file, dependent: :destroy
+    end
+
+    class VideoFile < ActiveRecord::Base
+      include DestroyedAt
+      belongs_to :user_question
+    end
+  end
+
+  ActiveRecord::Base.connection.execute(%{CREATE TABLE user_questions (id INTEGER PRIMARY KEY);})
+  ActiveRecord::Base.connection.execute(%{CREATE TABLE video_files (id INTEGER PRIMARY KEY,
+                                                                    destroyed_at DATETIME,
+                                                                    user_question_id INTEGER);})
+
+  it 'does not throw undefined_method when destroy! is called on a parent instance' do
+    user_question = Issue46::UserQuestion.create
+    Issue46::VideoFile.create(user_question: user_question)
+
+    result = Issue46::UserQuestion.last.destroy!
+    result.must_equal true
+  end
+end


### PR DESCRIPTION
Adds rake task for explicitly running issues_tests, which do not get run
via `rake test`.

Adds failing test for #46. 

This PR does not resolve the issue, but I wanted to get some eyes on the `issues_tests` idea @bcardarella @danmcclain. Basically, if we're debugging an issue, I'd like to preserve the work we get to the bottom of the issue, rather than building temporary `foo` tests.
