### PR TITLE
Fixes dependent destroy on has_one associations

### DIFF
--- a/lib/destroyed_at/has_one_association.rb
+++ b/lib/destroyed_at/has_one_association.rb
@@ -2,7 +2,7 @@ module DestroyedAt
   module HasOneAssociation
     def delete(method = options[:dependent])
       if load_target && method == :destroy
-        DestroyedAt.destroy_target_of_association(target, owner)
+        DestroyedAt.destroy_target_of_association(owner, target)
       else
         super
       end

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -81,6 +81,15 @@ describe 'destroying an activerecord instance' do
     Author.count.must_equal 0
     Avatar.count.must_equal 1
   end
+
+  it 'destroys a has_one child correctly with dependent destroy' do
+    avatar = Avatar.create
+    commenter = Commenter.create(avatar: avatar)
+    commenter.destroy!
+
+    Commenter.count.must_equal 0
+    Avatar.count.must_equal 0
+  end
 end
 
 describe 'restoring an activerecord instance' do

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -79,7 +79,7 @@ describe 'destroying an activerecord instance' do
     author.destroy!
 
     Author.count.must_equal 0
-    Avatar.count.must_equal 1
+    Avatar.count.must_equal 0
   end
 
   it 'destroys a has_one child correctly with dependent destroy' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,7 @@ ActiveRecord::Base.establish_connection(
 DatabaseCleaner.strategy = :truncation
 
 ActiveRecord::Base.connection.execute(%{CREATE TABLE authors (id INTEGER PRIMARY KEY);})
-ActiveRecord::Base.connection.execute(%{CREATE TABLE avatars (id INTEGER PRIMARY KEY, author_id INTEGER, destroyed_at DATETIME);})
+ActiveRecord::Base.connection.execute(%{CREATE TABLE avatars (id INTEGER PRIMARY KEY, author_id INTEGER, commenter_id INTEGER, destroyed_at DATETIME);})
 ActiveRecord::Base.connection.execute(%{CREATE TABLE categories (id INTEGER PRIMARY KEY);})
 ActiveRecord::Base.connection.execute(%{CREATE TABLE categorizations (id INTEGER PRIMARY KEY, category_id INTEGER, post_id INTEGER);})
 ActiveRecord::Base.connection.execute(%{CREATE TABLE comments (id INTEGER PRIMARY KEY, commenter_id INTEGER, post_id INTEGER, destroyed_at DATETIME);})
@@ -44,6 +44,7 @@ end
 class Avatar < ActiveRecord::Base
   include DestroyedAt
   belongs_to :author
+  belongs_to :commenter
 end
 
 class Category < ActiveRecord::Base
@@ -66,6 +67,7 @@ class Commenter < ActiveRecord::Base
   include DestroyedAt
   has_many :comments, dependent: :destroy
   has_many :posts, through: :comments
+  has_one :avatar, dependent: :destroy
 end
 
 class Post < ActiveRecord::Base


### PR DESCRIPTION
Hello,

It looks like the order of the arguments is backwards on ```DestroyedAt::HasOneAssociation#delete```. This causes unbounded recursion as the parent's destroy method is invoked in lieu of the child's.

For me, this issue manifests as a ```SystemStackError``` when attempting to destroy a model with a ```has_one :child, dependent :destroy```. Under other circumstances, it may also simply cause the destruction of the child to silently fail (as appears to be the case in [this spec](https://github.com/dockyard/ruby-destroyed_at/blob/f20088f746f884bd1c084518d60a21d54254bbdd/test/destroyed_at_test.rb#L76)).

Since I am using this gem in production, I have branched from what appears to be the current release version (there was no tag for 1.0.0, but the version was bumped to 1.0.0 in f20088f746f884bd1c084518d60a21d54254bbdd). On this branch I have corrected the issue, written a spec, and fixed the other seemingly incorrect test.

It would be nice to see this in the next release, so I don't have to keep a pesky Github entry in my Gemfile. :smile: 

Thanks!