### PR TITLE
Fixes arguments to `destroy_target_of_association`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1
+* Fixes an issue with where the incorrect arguments were being passed
+  from inside the `BelongsToAssociation` and `HasOneAssociation`, as
+reported by [anarchocurious](https://github.com/anarchocurious)
+
 ## 1.0.0
 
 * Requires equal to or greater than Ruby `2.0` -

--- a/lib/destroyed_at/belongs_to_association.rb
+++ b/lib/destroyed_at/belongs_to_association.rb
@@ -2,7 +2,7 @@ module DestroyedAt
   module BelongsToAssociation
     def handle_dependency
       if load_target && method == :destroy
-        DestroyedAt.destroy_target_of_association(target, owner)
+        DestroyedAt.destroy_target_of_association(owner, target)
       else
         super
       end

--- a/lib/destroyed_at/has_one_association.rb
+++ b/lib/destroyed_at/has_one_association.rb
@@ -2,7 +2,7 @@ module DestroyedAt
   module HasOneAssociation
     def delete(method = options[:dependent])
       if DestroyedAt.has_destroy_at?(target) && load_target && method == :destroy
-        DestroyedAt.destroy_target_of_association(target, owner)
+        DestroyedAt.destroy_target_of_association(owner, target)
       else
         super
       end

--- a/lib/destroyed_at/version.rb
+++ b/lib/destroyed_at/version.rb
@@ -1,3 +1,3 @@
 module DestroyedAt
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -79,7 +79,7 @@ describe 'destroying an activerecord instance' do
     author.destroy!
 
     Author.count.must_equal 0
-    Avatar.count.must_equal 1
+    Avatar.count.must_equal 0
   end
 end
 


### PR DESCRIPTION
This was caught by @anarchocurious – the `HasOnAssociation` and
`BelongsToAssociation` modules mistakenly swapped the order of the
`owner` and `target` arguments being passed to
`destroy_target_of_association`.