### PR TITLE
Fix belongs_to association

### DIFF
--- a/lib/destroyed_at/belongs_to_association.rb
+++ b/lib/destroyed_at/belongs_to_association.rb
@@ -1,7 +1,7 @@
 module DestroyedAt
   module BelongsToAssociation
     def handle_dependency
-      if load_target && method == :destroy
+      if DestroyedAt.has_destroy_at?(target) && load_target && options[:dependent] == :destroy
         DestroyedAt.destroy_target_of_association(owner, target)
       else
         super


### PR DESCRIPTION
I have a post model like this:

```ruby
class Post < ActiveRecord::Base
  include DestroyedAt
  belongs_to :postable, polymorphic: true, dependent: :destroy
end
```

When i destroy a post i get this error: `wrong number of arguments (0 for 1)`.

I'm not very familiar with Rails association internals, but i copied some things from the has_one assoc and it seems to work fine.

Using rails 4.2.4