### PR TITLE
Fixes the `handle_dependency` method for BelongsToAssociation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+* Associated models that do not include `DestroyedAt` will now be
+  **deleted** via `dependent: :destroy`. Previously, this was only the
+behavior for child records; however, child records can now delete the
+parent record (in accordance with default ActiveRecord behavior).
+
 ## 1.0.2
 * Fixes an issue in which
   `DestroyedAt::BelongsToAssociation#handle_dependency` was not deriving
@@ -6,7 +12,7 @@ an error for the wrong number of arguments. Thanks to
 [harmdewit](https://github.com/harmdewit) for catching this!
 
 ## 1.0.1
-* Fixes an issue with where the incorrect arguments were being passed
+* Fixes an issue where the incorrect arguments were being passed
   from inside the `BelongsToAssociation` and `HasOneAssociation`, as
 reported by [anarchocurious](https://github.com/anarchocurious)
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,9 @@ user.destroyed_at
 ```
 
 #### Warning: Dependent relations with destroy ####
-Be careful when destroying parent relationships that have `dependent:
-:destroy`. If the child
-relationship does not also `include DestroyedAt`, then when you call
-`#destroy` on the parent instance, you will delete the child record,
-rather than simply marking it `destroyed_at`.
-
-The same goes for destroying through relations that omit `include
-DestroyedAt`, even if the parent and child models include the mixin.
+Be careful when destroying models that have `dependent:
+:destroy`. This will **delete**, not destroy, the associated model if
+said model does not `include DestroyedAt`. 
 
 ### Restoring ####
 When you'd like to "restore" a record, call the `#restore` method on

--- a/lib/destroyed_at.rb
+++ b/lib/destroyed_at.rb
@@ -17,7 +17,8 @@ module DestroyedAt
   def self.destroy_target_of_association(owner, target)
     if target.respond_to?(:destroyed_at) && owner.respond_to?(:destroyed_at)
       target.destroy(owner.destroyed_at)
-    elsif target.respond_to?(:destroyed_at)
+    else
+      # this will delete the target if DestroyedAt is not included.
       target.destroy
     end
   end

--- a/lib/destroyed_at/version.rb
+++ b/lib/destroyed_at/version.rb
@@ -1,3 +1,3 @@
 module DestroyedAt
-  VERSION = "1.0.2"
+  VERSION = "2.0.0"
 end

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -196,13 +196,13 @@ describe 'non destroyed-at models' do
 end
 
 describe 'destroying a child that destroys its parent on destroy' do
-  it 'does not destroy a parent record without DestroyedAt' do
+  it 'destroys the parent record' do
     parent = Person.create!
     child = DestructiveChild.create!(person: parent)
 
     child.destroy
 
-    assert_equal(1, Person.count, 'Person must be one')
+    assert_equal(0, Person.count, 'Person must be one')
     assert_equal(0, DestructiveChild.count, 'DestructiveChild must be zero')
   end
 end


### PR DESCRIPTION
Previously, parent records that did not include `DestroyedAt` were not being deleted when a child record with `dependent: :destroy` was destroyed. This PR brings `DestroyedAt` inline with ActiveRecord and we will now delete the parent record if the child record gets destroyed and has `dependent: :destroy`.

This should be considered more of a fix, but since it could potentially introduce destructive changes to consuming applications, I'm going to issue this as a major release.