### PR TITLE
Allows mark_for_destruction to be passed a timestamp which will be used for future calls to destroy

### DIFF
--- a/lib/destroyed_at.rb
+++ b/lib/destroyed_at.rb
@@ -39,13 +39,19 @@ module DestroyedAt
 
   # Set an object's destroyed_at time.
   def destroy(timestamp = nil)
-    timestamp ||= current_time_from_proper_timezone
+    timestamp ||= @marked_for_destruction_at || current_time_from_proper_timezone
     raw_write_attribute(:destroyed_at, timestamp)
     run_callbacks(:destroy) do
       destroy_associations
       self.class.unscoped.where(self.class.primary_key => id).update_all(destroyed_at: timestamp)
       @destroyed = true
     end
+  end
+
+  def mark_for_destruction(timestamp = nil)
+    @marked_for_destruction_at = timestamp
+
+    super()
   end
 
   # Set an object's destroyed_at time to nil.

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -81,6 +81,21 @@ describe 'destroying an activerecord instance' do
     Author.count.must_equal 0
     Avatar.count.must_equal 0
   end
+
+  it 'destroys child with the correct datetime through an an autosaving association' do
+    datetime = 10.minutes.ago
+
+    commenter = Commenter.create
+
+    comment = commenter.comments.build
+    commenter.save
+
+    comment.mark_for_destruction(datetime)
+    commenter.save
+
+    comment.destroyed_at.must_equal datetime
+  end
+
 end
 
 describe 'restoring an activerecord instance' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,7 +76,7 @@ end
 
 class Commenter < ActiveRecord::Base
   include DestroyedAt
-  has_many :comments, dependent: :destroy
+  has_many :comments, dependent: :destroy, autosave: true
   has_many :posts, through: :comments
 end
 


### PR DESCRIPTION
This is useful when using autosaving associations. 

For example, in an application that periodically syncs with a client, it is nice to allow the client to pass a ```destroyed_at``` key for a record that needs to be deleted ```accepts_nested_attributes_for``` style.