### PR TITLE
Fix polymorphic associations

### DIFF
--- a/lib/destroyed_at/has_one_association.rb
+++ b/lib/destroyed_at/has_one_association.rb
@@ -1,7 +1,7 @@
 module DestroyedAt
   module HasOneAssociation
     def delete(method = options[:dependent])
-      if DestroyedAt.has_destroy_at?(target) && load_target && method == :destroy
+      if load_target && DestroyedAt.has_destroy_at?(target) && method == :destroy
         DestroyedAt.destroy_target_of_association(owner, target)
       else
         super

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -116,6 +116,8 @@ describe 'restoring an activerecord instance' do
     Comment.count.must_equal 1
   end
 
+  it 'restores a'
+
   it 'does not restore a non-dependent relation with DestroyedAt' do
     Post.count.must_equal 0
     Author.count.must_equal 0
@@ -184,7 +186,7 @@ describe 'creating a destroyed record' do
 end
 
 describe 'non destroyed-at models' do
-  it 'can destroy has_on dependants' do
+  it 'can destroy has_one dependants' do
     person = Person.create!
     person.create_pet!
 

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -108,6 +108,34 @@ describe 'restoring an activerecord instance' do
     initial_count.must_equal post.validation_count
   end
 
+  it 'restores polymorphic has_many relation with DestroyedAt' do
+    comment = Comment.create
+    like = Like.create(likeable: comment)
+    comment.destroy
+
+    Comment.count.must_equal 0
+    Like.count.must_equal 0
+
+    comment.reload
+    comment.restore
+    Comment.count.must_equal 1
+    Like.count.must_equal 1
+  end
+
+  it 'restores polymorphic has_one relation with DestroyedAt' do
+    post = Post.create
+    like = Like.create(likeable: post)
+    post.destroy
+
+    Post.count.must_equal 0
+    Like.count.must_equal 0
+
+    post.reload
+    post.restore
+    Post.count.must_equal 1
+    Like.count.must_equal 1
+  end
+
   it 'restores a dependent has_many relation with DestroyedAt' do
     Comment.create(:destroyed_at => timestamp, :post => post)
     Comment.count.must_equal 0
@@ -115,8 +143,6 @@ describe 'restoring an activerecord instance' do
     post.restore
     Comment.count.must_equal 1
   end
-
-  it 'restores a'
 
   it 'does not restore a non-dependent relation with DestroyedAt' do
     Post.count.must_equal 0

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -110,7 +110,7 @@ describe 'restoring an activerecord instance' do
 
   it 'restores polymorphic has_many relation with DestroyedAt' do
     comment = Comment.create
-    like = Like.create(likeable: comment)
+    Like.create(likeable: comment)
     comment.destroy
 
     Comment.count.must_equal 0
@@ -124,7 +124,7 @@ describe 'restoring an activerecord instance' do
 
   it 'restores polymorphic has_one relation with DestroyedAt' do
     post = Post.create
-    like = Like.create(likeable: post)
+    Like.create(likeable: post)
     post.destroy
 
     Post.count.must_equal 0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,7 @@ ActiveRecord::Base.connection.execute(%{CREATE TABLE images (id INTEGER PRIMARY 
 ActiveRecord::Base.connection.execute(%{CREATE TABLE posts (id INTEGER PRIMARY KEY, author_id INTEGER, destroyed_at DATETIME);})
 ActiveRecord::Base.connection.execute(%{CREATE TABLE people (id INTEGER PRIMARY KEY);})
 ActiveRecord::Base.connection.execute(%{CREATE TABLE pets (id INTEGER PRIMARY KEY, person_id INTEGER);})
+ActiveRecord::Base.connection.execute(%{CREATE TABLE likes (id INTEGER PRIMARY KEY, likeable_id INTEGER, likeable_type TEXT, destroyed_at DATETIME);})
 
 class Author < ActiveRecord::Base
   has_many :posts
@@ -68,10 +69,17 @@ class Categorization < ActiveRecord::Base
   belongs_to :post
 end
 
+class Like < ActiveRecord::Base
+  include DestroyedAt
+  belongs_to :likeable, polymorphic: true
+end
+
 class Comment < ActiveRecord::Base
   include DestroyedAt
   belongs_to :post
   belongs_to :commenter
+
+  has_many :likes, as: :likeable, dependent: :destroy
 end
 
 class Commenter < ActiveRecord::Base
@@ -92,6 +100,7 @@ class Post < ActiveRecord::Base
   has_many :categorizations, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :commenters, through: :comments
+  has_one :like, as: :likeable, dependent: :destroy
 
   before_destroy :increment_destroy_callback_counter
   before_restore :increment_restore_callback_counter


### PR DESCRIPTION
Fixes dependencies don't have the same destroyed_at timestamp. If it's not the same
we can't properly restore dependencies. So this commit fixes it.