### PR TITLE
Properly call destroy method so after_commit callback is called.

### DIFF
--- a/lib/destroyed_at.rb
+++ b/lib/destroyed_at.rb
@@ -39,7 +39,7 @@ module DestroyedAt
 
   # Set an object's destroyed_at time.
   def destroy(timestamp = nil)
-    transaction do
+    with_transaction_returning_status do
       timestamp ||= @marked_for_destruction_at || current_time_from_proper_timezone
       raw_write_attribute(:destroyed_at, timestamp)
 

--- a/test/destroyed_at_test.rb
+++ b/test/destroyed_at_test.rb
@@ -269,3 +269,11 @@ describe 'destroying a child that destroys its parent on destroy' do
   end
 end
 
+describe 'destroying on object should call after_commit callback' do
+  it 'calls after_commit callback on: :destroy' do
+    comment = Comment.create
+    comment.destroy
+
+    comment.after_committed.must_equal true
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -80,6 +80,14 @@ class Comment < ActiveRecord::Base
   belongs_to :commenter
 
   has_many :likes, as: :likeable, dependent: :destroy
+
+  after_commit :set_after_committed_flag, on: :destroy
+
+  attr_reader :after_committed
+
+  def set_after_committed_flag
+    @after_committed = true
+  end
 end
 
 class Commenter < ActiveRecord::Base


### PR DESCRIPTION
I couldn't find an easy way to test that method is called in minitest though.
fixes #56 