### PR TITLE
adds rails 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 rvm:
-- 2.0.0
-- 2.1.0
+- 2.2.2
+- 2.3.1
 
 before_install:
 - gem install bundler -v '= 1.5.1'

--- a/destroyed_at.gemspec
+++ b/destroyed_at.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_runtime_dependency "activerecord", '~> 4.1'
-  spec.add_runtime_dependency 'actionpack', '~> 4.1'
+  spec.add_runtime_dependency "activerecord", "~> 5.0"
+  spec.add_runtime_dependency "actionpack", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/destroyed_at.rb
+++ b/lib/destroyed_at.rb
@@ -29,10 +29,7 @@ module DestroyedAt
 
   module ClassMethods
     def destroyed(time = nil)
-      query = where.not(destroyed_at: nil)
-      query.where_values.reject! do |node|
-        Arel::Nodes::Equality === node && node.left.name == 'destroyed_at' && node.right.nil?
-      end
+      query = unscope(where: :destroyed_at)
       time ? query.where(destroyed_at: time) : query.where.not(destroyed_at: nil)
     end
   end

--- a/lib/destroyed_at/has_many_association.rb
+++ b/lib/destroyed_at/has_many_association.rb
@@ -9,7 +9,7 @@ module DestroyedAt
             r.destroy
           end
         end
-        update_counter(-records.length) unless inverse_updates_counter_cache?
+        update_counter(-records.length) unless reflection.inverse_updates_counter_cache?
       else
         super
       end


### PR DESCRIPTION
This could be considered a work in progress.
1. Loosen the gemspec to allow Rails 5 installation.
2. Use [unscope](http://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-unscope) method instead of `#where_values` which is no longer part of Rails 5.
3. `inverse_updates_counter_cache?` was removed and must be accessed through `reflection`.
